### PR TITLE
fix: update twitter icon to x

### DIFF
--- a/root/images/twitter_icon.svg
+++ b/root/images/twitter_icon.svg
@@ -1,35 +1,7 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   id="svg8508"
-   version="1.1"
-   viewBox="0 0 8.4666665 8.4666663"
-   height="32"
-   width="32">
-  <defs
-     id="defs8502" />
-  <metadata
-     id="metadata8505">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     transform="translate(157.69163,73.11427)"
-     id="layer1">
-    <path
-       id="path83421"
-       d="m -153.42647,-73.114289 a 4.2333327,4.2333327 0 0 0 -4.2333,4.2334 4.2333327,4.2333327 0 0 0 4.2333,4.233299 4.2333327,4.2333327 0 0 0 4.2333,-4.233299 4.2333327,4.2333327 0 0 0 -4.2333,-4.2334 z m 1.1606,1.7865 c 0.3554,0 0.6766,0.1505 0.9018,0.3905 0.2815,-0.055 0.5458,-0.1582 0.7845,-0.2998 -0.092,0.2884 -0.2882,0.5303 -0.5432,0.6832 0.2498,-0.03 0.4877,-0.097 0.709,-0.1947 -0.1653,0.2476 -0.3749,0.4654 -0.6159,0.6397 v 0.1598 c 0,1.632 -1.2426,3.5145 -3.5146,3.5145 v 5.02e-4 c -0.6979,0 -1.3468,-0.2048 -1.8934,-0.5551 0.097,0.017 0.1945,0.017 0.2946,0.017 0.5784,0 1.1113,-0.1972 1.5342,-0.5287 -0.5406,-0.01 -0.9967,-0.3675 -1.1539,-0.8583 0.075,0.012 0.153,0.023 0.232,0.023 0.113,0 0.222,-0.015 0.3256,-0.044 -0.5654,-0.1133 -0.9912,-0.6131 -0.9912,-1.2113 v -0.016 c 0.1664,0.094 0.357,0.1436 0.5597,0.1545 -0.3314,-0.2212 -0.5499,-0.5993 -0.5499,-1.0276 0,-0.2265 0.062,-0.4387 0.1675,-0.6213 0.6093,0.7475 1.5196,1.2388 2.5461,1.2909 -0.019,-0.091 -0.031,-0.1852 -0.031,-0.282 0,-0.6819 0.5533,-1.2351 1.2355,-1.2351 z"
-       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4.59789085;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke" />
-  </g>
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="16" fill="white" />
+
+  <svg x="6" y="6" width="20" height="20" fill="#4a4a4a" viewBox="0 0 16 16">
+    <path d="M12.6.75h2.454l-5.36 6.142L16 15.25h-4.937l-3.867-5.07-4.425 5.07H.316l5.733-6.57L0 .75h5.063l3.495 4.633L12.601.75Zm-.86 13.028h1.36L4.323 2.145H2.865z"/>
+  </svg>
 </svg>


### PR DESCRIPTION
Fixes #3 
Icon has been updated.

<img width="241" height="150" alt="Screenshot 2025-10-02 at 6 55 56 PM" src="https://github.com/user-attachments/assets/c2a8acda-8493-41c8-9829-c5926ca55bfd" />
